### PR TITLE
chore: Update GoReleaser args to skip Chocolatey distribution during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean
+          args: release --clean --skip=chocolateys
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}


### PR DESCRIPTION
…release